### PR TITLE
Prevent queue from blocking forever on lock acquisition

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
---format=nested
 --backtrace

--- a/filequeue.gemspec
+++ b/filequeue.gemspec
@@ -47,5 +47,7 @@ Gem::Specification.new do |s|
     end
   else
   end
+
+  s.add_development_dependency :rspec, "~> 3.3"
 end
 

--- a/spec/filequeue_spec.rb
+++ b/spec/filequeue_spec.rb
@@ -80,9 +80,9 @@ describe FileQueue do
   
   describe '#empty' do
     it 'should tell you if the queue is empty or not' do
-      subject.empty?.should be_true
+      subject.empty?.should be true
       subject.push "content"
-      subject.empty?.should be_false
+      subject.empty?.should be false
     end
   end
   
@@ -90,12 +90,12 @@ describe FileQueue do
     it 'should empty the queue' do
       subject.push "content"
       subject.clear
-      subject.empty?.should be_true
+      subject.empty?.should be true
     end
   end
   
   describe '#safe_open' do
-    pending 'should lock files when doing IO (implemented, but cannot test)' do
+    skip 'should lock files when doing IO (implemented, but cannot test)' do
       # After reading the definition of File#flock more closely (http://www.ruby-doc.org/core/classes/File.html#M000040) I'm realizing that the LOCK_EX is process wide and won't block access to anything inside the current process. This means that in the same process that you lock a file in you will not be blocked from that file, so in a test you can't simulate what it is like to be blocked access without spawning a new process.
       # From what I can tell 1.8.7 can't really spawn new processes. 1.9.2 has Process#spawn which in theory would allow the testing of the flocking LOCK_EX block but I have not tested it.
     end

--- a/spec/filequeue_spec.rb
+++ b/spec/filequeue_spec.rb
@@ -99,5 +99,7 @@ describe FileQueue do
       # After reading the definition of File#flock more closely (http://www.ruby-doc.org/core/classes/File.html#M000040) I'm realizing that the LOCK_EX is process wide and won't block access to anything inside the current process. This means that in the same process that you lock a file in you will not be blocked from that file, so in a test you can't simulate what it is like to be blocked access without spawning a new process.
       # From what I can tell 1.8.7 can't really spawn new processes. 1.9.2 has Process#spawn which in theory would allow the testing of the flocking LOCK_EX block but I have not tested it.
     end
+
+    skip 'should raise FileLockError if unable to acquire lock' # see above
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,22 +1,7 @@
 require 'rubygems'
 require 'rspec'
-require 'rspec/autorun'
 require 'filequeue'
 
-class File
-  def flocked? &block
-    status = flock LOCK_EX | LOCK_NB
-    case status
-      when false
-        return true 
-      when 0
-        begin
-          block ? block.call : false
-        ensure
-          flock LOCK_UN
-        end
-      else
-        raise SystemCallError, status 
-    end
-  end
+RSpec.configure do |c|
+  c.expect_with(:rspec) { |c| c.syntax = :should }
 end


### PR DESCRIPTION
Add the nonblocking flag to flock and retry if the lock fails. Give up after a number of tries. 

Also, upgraded to newer version of rspec.
