### PR TITLE
Perform file locking using the Filelock gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in filequeue.gemspec
 gemspec
+
+gem 'filelock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    filelock (1.1.1)
     rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -26,9 +27,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  filelock
   filequeue!
   rake
   rspec (~> 3.3)
 
 BUNDLED WITH
-   1.10.6
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 
 
 ## FileQueue [![Build Status](https://travis-ci.org/pezra/filequeue.svg)](https://travis-ci.org/pezra/filequeue)
-...is a simple file based queue written in Ruby that uses the Ruby `File` class in standard library to push and pop items into a queue. It's not web scale but is nice for lightweight async queuing apps.
-
-Originally written by [daddz](http://www.github.com/daddz) and found in [this gist](https://gist.github.com/352509). Thanks, daddz!
+A simple file based queue written in Ruby that uses the battle-tested [`Filelock`](https://github.com/sheerun/filelock) gem to push and pop items into a queue. It's not web scale but is nice for lightweight async queuing apps.
 
 ## Install
 
-    gem install filequeue
+```ruby
+gem install filequeue
+```
 
 ## Usage
 
@@ -32,3 +32,8 @@ See `spec/filequeue_spec.rb` for more usage details
 * `length`
 * `empty?`
 * `clear`
+
+## Authorship
+
+* Origially written by [daddz](http://www.github.com/daddz) and found in [this gist](https://gist.github.com/352509).
+* Ported to a Rubygem by [@pezra](https://github.com/pezra).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ See `spec/filequeue_spec.rb` for more usage details
 * `empty?`
 * `clear`
 
+## Dependencies
+
+Locking is delegated to the excellent [`Filelock`](https://github.com/sheerun/filelock) gem.
+All of the `Filelock`'s [caveats](https://github.com/sheerun/filelock#faq) apply.
+
+## Limitations
+
+* NFS is [not supported](https://github.com/sheerun/filelock#faq)
+
 ## Authorship
 
 * Origially written by [daddz](http://www.github.com/daddz) and found in [this gist](https://gist.github.com/352509).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,3 @@ See `spec/filequeue_spec.rb` for more usage details
 * `length`
 * `empty?`
 * `clear`
-
-## Continuous Integration
-
-[![Build Status](http://travis-ci.org/maxogden/filequeue.png)](http://travis-ci.org/maxogden/filequeue)

--- a/README.md
+++ b/README.md
@@ -11,15 +11,27 @@ Originally written by [daddz](http://www.github.com/daddz) and found in [this gi
 
 ## Usage
 
-    queue = FileQueue.new 'queue_party.txt'
-    
-    queue.push "an item"
-      => true
+```ruby
+queue = FileQueue.new 'queue_party.txt'
+
+queue.push "an item"
+#  => true
       
-    queue.pop
-      => "an item"
-      
+queue.pop
+#  => "an item"
+```
+
 See `spec/filequeue_spec.rb` for more usage details
+
+## Docs
+
+`FileQueue` has the following class methods:
+
+* `push` (alias `<<`)
+* `pop`
+* `length`
+* `empty?`
+* `clear`
 
 ## Continuous Integration
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
+# FileQueue [![Build Status](https://travis-ci.org/pezra/filequeue.svg)](https://travis-ci.org/pezra/filequeue)
 
-
-## FileQueue [![Build Status](https://travis-ci.org/pezra/filequeue.svg)](https://travis-ci.org/pezra/filequeue)
 A simple file based queue written in Ruby that uses the battle-tested [`Filelock`](https://github.com/sheerun/filelock) gem to push and pop items into a queue. It's not web scale but is nice for lightweight async queuing apps.
 
 ## Install
@@ -15,10 +14,10 @@ gem install filequeue
 queue = FileQueue.new 'queue_party.txt'
 
 queue.push "an item"
-#  => true
-      
+# => true
+
 queue.pop
-#  => "an item"
+# => "an item"
 ```
 
 See `spec/filequeue_spec.rb` for more usage details

--- a/lib/filequeue.rb
+++ b/lib/filequeue.rb
@@ -69,7 +69,7 @@ class FileQueue
       Thread.pass
     end
 
-    (raise FileLockError, "Queue file appears to be permanently lockecd") unless lock_acquired
+    (raise FileLockError, "Queue file appears to be permanently locked") unless lock_acquired
   end
 
   FileLockError = Class.new(Timeout::Error)


### PR DESCRIPTION
This PR:

* Switches to  the well-tested [Filelock](https://github.com/sheerun/filelock) gem for locking.
* All test still pass.

Why switch to [Filelock](https://github.com/sheerun/filelock)?
* It seems to be really well tested (see [this spec file].(https://github.com/sheerun/filelock/blob/master/spec/filelock_spec.rb)).
* It guarantees correct behavior on MRI, JRuby & Rubinius.
* It unlocks potential future features, such as custom wait timeouts (using the `:wait` option), and max blocking time (using the `:timeout` option).

[Filelock](https://github.com/sheerun/filelock) cons:
* Drops support for the `NFS` file system (no [Filelock](https://github.com/sheerun/filelock) support).
* Adds a dependency.